### PR TITLE
Create a custom Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/docker.yml
+      - docker/build
+      - docker/Dockerfile
+      - docker/env.yaml
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: docker
+    steps:
+
+    - uses: actions/checkout@v5
+
+    # Uncomment this if you are building for a non-native --platform
+    # - uses: docker/setup-qemu-action@v3
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push image
+      run: |
+        image_tag="ghcr.io/${{ github.repository }}:${{ github.run_id }}"
+        latest_tag="ghcr.io/${{ github.repository }}:latest"
+
+        ./build \
+          --tag "$image_tag" \
+          --tag "$latest_tag" \
+          --push \
+          --cache-from=type=registry,ref="$latest_tag"
+
+        cat >"$GITHUB_STEP_SUMMARY" <<~~
+        Image successfully published.
+
+        Pull the image for local use:
+
+            docker pull $image_tag
+        ~~

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM nextstrain/base:latest
+
+# Run the final setup as our target user for permissions reasons.
+USER nextstrain:nextstrain
+
+# Install Miniforge (includes conda)
+RUN curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh" -o miniforge.sh && \
+    bash miniforge.sh -b -p /nextstrain/miniforge && \
+    rm miniforge.sh
+
+# Make conda available in PATH
+ENV PATH="/nextstrain/miniforge/condabin:$PATH"
+
+# Initialize conda for interactive shell use
+RUN conda init bash \
+ && conda config --set auto_activate_base false
+
+
+# Create conda environments
+# Add global write bits, similar to what's done for /nextstrain¹, but
+# recursively on the conda environment directory. This allows `tb-profiler
+# update_tbdb` to write to the directory at run time under a different UID.
+# ¹ <https://github.com/nextstrain/docker-base/blob/9270fb321251b298b332b648f2744308bb2d89ff/Dockerfile#L430-L431>
+
+RUN conda create -y --name snippy \
+      -c conda-forge -c bioconda \
+      sra-tools=3.2.1 \
+      snippy=4.6.0 \
+ && conda clean -afy \
+ && rm -rf ~/.cache \
+ && chmod -R a+rwXt /nextstrain/miniforge/envs/snippy
+
+RUN conda create -y --name tb-profiler \
+      -c conda-forge -c bioconda \
+      sra-tools=3.2.1 \
+      tb-profiler=6.6.5 \
+ && conda clean -afy \
+ && rm -rf ~/.cache \
+ && chmod -R a+rwXt /nextstrain/miniforge/envs/tb-profiler
+
+RUN conda create -y --name duckdb \
+      -c conda-forge \
+      duckdb-cli \
+ && conda clean -afy \
+ && rm -rf ~/.cache \
+ && chmod -R a+rwXt /nextstrain/miniforge/envs/duckdb
+
+# Switch back to root.  The entrypoint will drop to nextstrain:nextstrain as
+# necessary when a container starts.
+USER root

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,38 @@
+## Overview
+
+The contents of this folder are used to create a Docker image that extends the
+Nextstrain base image with tools necessary for running tuberculosis analyses.
+
+## Usage
+
+The automated build process happens in the
+[docker.yml](../.github/workflows/docker.yml) GitHub Actions workflow. The
+scripts can also be used locally. Loading and tagging the image is optional but
+recommended for ease of use and removal.
+
+    cd docker
+    ./build --load --tag nextstrain-tb
+
+The conda environments may not resolve on the `linux/arm64` platform (used by
+default on Apple silicon computers). A workaround is to emulate for
+`linux/amd64` (used by default in the GitHub Actions workflow), noting that emulation means slower build and run times.
+
+    ./build --load --tag nextstrain-tb --platform linux/amd64
+
+The image size is expected to be ~9 GB uncompressed. The builder volume size is expected to be ~4.5 GB.
+
+The image extends the Nextstrain base image, so it is compatible with Nextstrain CLI.
+
+    nextstrain shell --image nextstrain-tb .
+
+To reclaim disk space, remove the builder and the tagged image.
+
+    ./clean
+    docker image rm nextstrain-tb
+
+## References
+
+Adapted from
+[victorlin/github-actions-docker-build](https://github.com/victorlin/github-actions-docker-build),
+which is based on work in
+[nextstrain/docker-base](https://github.com/nextstrain/docker-base).

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Build the image.
+#
+set -euo pipefail
+
+# `buildx create` is necessary to use a driver that supports multi-platform
+# images.
+builder=nextstrain-tb-builder
+
+
+if ! docker buildx inspect "$builder" &>/dev/null; then
+    # Using a persistent builder allows for faster local development.
+    # However, if this is changed and it was previously run on your machine,
+    # you may need to remove the builder manually before running the script:
+    #     docker buildx rm "custom-builder"
+    docker buildx create --use --name "$builder" --driver docker-container --driver-opt network=host
+fi
+
+docker buildx build "$@" .

--- a/docker/clean
+++ b/docker/clean
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Cleans up after the build process by removing build artifacts, caches, and logs.
+#
+set -euo pipefail
+
+
+builder=nextstrain-tb-builder
+
+
+echo "--> Deleting $builder (and its caches)"
+
+if docker buildx inspect "$builder" &>/dev/null; then
+    docker buildx du --builder "$builder"
+    docker buildx rm --builder "$builder"
+else
+    echo "skipped; $builder does not exist"
+fi


### PR DESCRIPTION
## Description of proposed changes

The tools included in the Nextstrain base image (nextstrain/base) are primarily meant for viral analyses. Bacterial analyses – in this case, tuberculosis – require a different set of tools. While these tools may eventually make their way into the Nextstrain base image, for now we will maintain a separate image that extends nextstrain/base with the necessary additions.

Conda environments are not the only way to add these tools – and they aren't the most efficient use of Docker layers – but they are relatively easy to maintain. The package recipes already handle the complex build processes for these tools, which would otherwise be difficult to reproduce in a Dockerfile.

See the new README file for details on building the image.

## Related issue(s)

Follow-up to https://github.com/nextstrain/tb/pull/17#discussion_r2366413000

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Image build is successful in fork repo](https://github.com/victorlin/tb/actions/runs/18109704594)
- [x] Tested the built image

    <details>

    3.29 GB compressed:

    ```
    docker run --rm quay.io/skopeo/stable \
      inspect --override-arch=amd64 --override-os=linux \
      docker://ghcr.io/victorlin/tb:latest \
    | jq -r '[.LayersData[] | {d:.Digest, s:.Size}]      # digest + size
          | unique_by(.d)                                # de-dupe by digest
          | map(.s)                                      # take sizes
          | add as $b                                    # sum bytes
          | ((($b/1000000000)*100|floor)/100|tostring) + " GB"'
    3.29 GB
    ```

    Pull image and start a Nextstrain shell with it

    ```
    docker pull --platform linux/amd64 ghcr.io/victorlin/tb:latest
    nextstrain shell --image ghcr.io/victorlin/tb:latest .
    ```

    Run some commands

    ```
    conda activate duckdb
    duckdb --help
    ```

    </details>

- [x] Checks pass
- [x] ~Update changelog~ no changelog
- [ ] Post-merge: image build is successful in this repo