### PR TITLE
Don't translate rrs gene

### DIFF
--- a/config/genes.txt
+++ b/config/genes.txt
@@ -32,7 +32,6 @@ ahpC
 rpoB
 pncA
 rpsL
-rrs
 gyrA
 gyrB
 ethA


### PR DESCRIPTION
## Description of proposed changes

This is not a protein coding gene, so it should not be translated.

Translating it currently comes with a warning

    Gene length of 'rrs' is not a multiple of 3. will pad with N

which will soon be changed to an error

    ERROR: Reference file 'config/Mtb_H37Rv_NCBI_Annot.gff' has errors:
        'rrs' has length 1537 which is not a multiple of 3.

## Related issue(s)

https://github.com/nextstrain/augur/issues/1895

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Tested locally with [Augur PR](https://github.com/nextstrain/augur/pull/1901) – `augur translate` runs with no warnings or errors
- [x] ~Update changelog~ no changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
