### PR TITLE
Ignore SnpEff 5.3.0a

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN conda create -y --name tb-profiler \
       -c conda-forge -c bioconda \
       sra-tools=3.2.1 \
       tb-profiler=6.6.5 \
+      snpeff!=5.3.0a \
  && conda clean -afy \
  && rm -rf ~/.cache \
  && chmod -R a+rwXt /nextstrain/miniforge/envs/tb-profiler


### PR DESCRIPTION
## Description of proposed changes

One of the Bioconda builds of this version did not properly declare a dependency of Java version >= 21. This has been addressed with a newer build of the same version, but the Conda solver still prefers the broken build.

Since there [isn't a way](https://stackoverflow.com/q/77097829) to specifically exclude the bad build of this version, the next best solution is to exclude the version entirely.

## Related issue(s)

Closes #25

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested locally: Docker image build pulls SnpEff 5.2
- [x] SnpEff works in `ghcr.io/nextstrain/tb:18605026942`

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
