### PR TITLE
Change branch reference from `master` to `main`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/docker.yml
       - docker/build


### PR DESCRIPTION
## Description of proposed changes

We are planning to rename the `master` branch to `main` and so we need to change the branch reference in `docker.yml`

@victorlin [did a check](https://bedfordlab.slack.com/archives/C07U8J5N465/p1760986127657779?thread_ts=1760985854.837259&cid=C07U8J5N465) and this was the only change needed.

## Related issue(s)
https://github.com/nextstrain/public/issues/8
Closes https://github.com/nextstrain/tb/issues/10
https://github.com/nextstrain/tb/pull/23#issuecomment-3353704525

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Rename `master` branch to `main`
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
