### PR TITLE
Remove mixed-lineage samples

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -303,6 +303,7 @@ checkpoint filter_qc:
         | tsv-filter --header --gt  target_median_depth:30 \
         | tsv-filter --header --gt  ALIGNED:3529226 \
         | tsv-filter --header --str-eq main_lineage:M.canetti  --invert \
+        | tsv-filter --header --str-not-in-fld main_lineage:';' \
         > {output.metadata_filtered}
         """
 


### PR DESCRIPTION
## Description of proposed changes

When [tbprofiler](https://github.com/jodyphelan/TBProfiler) assigns a sample to multiple lineages, it likely indicates a [mixed-strain infection](https://jodyphelan.github.io/tb-profiler-docs/en/lineages/), and we want to remove those samples from the analysis. tbprofiler reports multiple lineage assignments by listing the main lineages separated by a semicolon, e.g. "lineage3;lineage4". This PR removes likely mixed-strain samples by filtering out any sample with a main lineage assignment that contains a semicolon.

Output of a test run is here: https://nextstrain.org/staging/tb/global/nomixedstrains

That can be compared with example output from a run without removing mixed strains: https://nextstrain.org/tb/global@2025-10-16

## Related issue(s)
https://github.com/nextstrain/tb/issues/27

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
